### PR TITLE
Support bitmap fonts in XNAControls. Rewrite text splitter and add features

### DIFF
--- a/XNAControls.Test/TextSplitterTest.cs
+++ b/XNAControls.Test/TextSplitterTest.cs
@@ -56,26 +56,32 @@ namespace XNAControls.Test
 
         [Test]
         [Timeout(2000)]
-        public void GivenLongMessageWithLongWords1_WhenSplittingAt200px_ShouldBe3LinesOfText()
+        public void GivenLongMessageWithLongWordsAndLineBreaks_WhenSplittingAt150px_HasExpectedLineBreaksAndHyphens()
         {
-            _ts.Text = "Testttttttttttttttttttttttttttttttttttttttttttttttttttt messageeeeeeeeeeeeeeeeeeeeeeeeee oneee";
-            _ts.LineLength = 200;
+            _ts.Text = "Testtwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n\nmessagewwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww oneee";
+            _ts.LineLength = 100;
 
             var result = _ts.SplitIntoLines();
 
-            Assert.AreEqual(3, result.Count);
+            Assert.That(result, Has.Count.EqualTo(6));
+            Assert.That(result, Has.None.StartsWith(" "));
+            Assert.That(result[0], Does.EndWith(_ts.Hyphen));
+            Assert.That(result[3], Does.EndWith(_ts.Hyphen));
         }
 
         [Test]
         [Timeout(2000)]
-        public void GivenLongMessageWithLongWords2_WhenSplittingAt200px_ShouldBe5LinesOfText()
+        public void GivenLongMessageWithLongWords_WhenSplittingAt200px_ShouldHyphenateLongWordsBeyondHardBreak()
         {
             _ts.Text = "Test messageeeeeeeeeeeeeeeeeeeeeeeeee oneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-            _ts.LineLength = 200;
+            _ts.LineLength = 190;
+            _ts.HardBreak = 200;
 
             var result = _ts.SplitIntoLines();
 
-            Assert.AreEqual(4, result.Count);
+            Assert.That(result, Has.Count.EqualTo(3));
+            Assert.That(result, Has.None.StartsWith(" "));
+            Assert.That(result.Take(2), Has.All.EndsWith(_ts.Hyphen));
         }
 
         [Test]
@@ -128,8 +134,8 @@ namespace XNAControls.Test
 
             var result = _ts.SplitIntoLines();
 
-            Assert.IsTrue(result.Where(x => x != string.Empty).Except(new[] { result.Last() }).All(x => x.EndsWith(_ts.LineEnd)));
-            Assert.IsFalse(result.Last().EndsWith(_ts.LineEnd));
+            Assert.That(result.Where(x => x != string.Empty).Except(new[] { result.Last() }), Has.All.EndsWith(_ts.LineEnd));
+            Assert.That(result.Last(), Does.Not.EndWith(_ts.LineEnd));
         }
 
         [Test]
@@ -142,8 +148,8 @@ namespace XNAControls.Test
 
             var result = _ts.SplitIntoLines();
 
-            Assert.IsFalse(result.First().StartsWith(_ts.LineIndent));
-            Assert.IsTrue(result.Except(new[] { result.First() }).All(x => x.StartsWith(_ts.LineIndent)));
+            Assert.That(result.First(), Does.Not.StartWith(_ts.LineIndent));
+            Assert.That(result.Skip(1), Has.All.StartsWith(_ts.LineIndent));
         }
 
         [Test]
@@ -170,8 +176,8 @@ namespace XNAControls.Test
 
             var result = _ts.SplitIntoLines();
 
-            Assert.That(result, Has.Count.EqualTo(2));
-            CollectionAssert.AreEqual(new[] { ExpectedString, string.Empty }, result);
+            Assert.That(result, Has.Count.EqualTo(3));
+            CollectionAssert.AreEqual(new[] { ExpectedString, string.Empty, string.Empty }, result);
         }
 
         [Test]
@@ -185,7 +191,7 @@ namespace XNAControls.Test
                 "Other content"
             };
 
-            _ts.Text = $"{expectedLines[0]}\n{expectedLines[1]}\n{expectedLines[2]}\n{expectedLines[3]}\n";
+            _ts.Text = $"{expectedLines[0]}\n{expectedLines[1]}\n{expectedLines[2]}\n{expectedLines[3]}";
             _ts.LineLength = 254;
 
             var result = _ts.SplitIntoLines();

--- a/XNAControls.Test/TextSplitterTest.cs
+++ b/XNAControls.Test/TextSplitterTest.cs
@@ -56,10 +56,12 @@ namespace XNAControls.Test
 
         [Test]
         [Timeout(2000)]
-        public void GivenLongMessageWithLongWordsAndLineBreaks_WhenSplittingAt150px_HasExpectedLineBreaksAndHyphens()
+        public void GivenLongMessageWithLongWordsAndLineBreaks_WhenSplittingAt100px_HasExpectedLineBreaksAndHyphens()
         {
             _ts.Text = "Testtwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n\nmessagewwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww oneee";
-            _ts.LineLength = 100;
+            _ts.LineLength = 150;
+            _ts.HardBreak = 150;
+            _ts.Hyphen = "-";
 
             var result = _ts.SplitIntoLines();
 
@@ -76,6 +78,7 @@ namespace XNAControls.Test
             _ts.Text = "Test messageeeeeeeeeeeeeeeeeeeeeeeeee oneeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
             _ts.LineLength = 190;
             _ts.HardBreak = 200;
+            _ts.Hyphen = "-";
 
             var result = _ts.SplitIntoLines();
 
@@ -90,6 +93,8 @@ namespace XNAControls.Test
         {
             _ts.Text = "This is a test message in which the words should be able to easily be split into multiple lines";
             _ts.LineLength = 200;
+            _ts.HardBreak = 200;
+            _ts.Hyphen = "-";
 
             var result = _ts.SplitIntoLines();
 
@@ -181,6 +186,7 @@ namespace XNAControls.Test
         }
 
         [Test]
+        [Timeout(2000)]
         public void GivenMessageWithMultipleNewLineCharacters_WhenSplittingAt254px_HasExpectedLineCountAndContents()
         {
             var expectedLines = new[]
@@ -197,6 +203,47 @@ namespace XNAControls.Test
             var result = _ts.SplitIntoLines();
 
             Assert.That(result, Has.Count.EqualTo(4));
+            CollectionAssert.AreEqual(expectedLines, result);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void GivenMessageWhereLastWordHasTrailingNewLines_WhenSplitting_HasExpectedNumberOfNewlines()
+        {
+            var expectedLines = new[]
+            {
+                "This is a long string where the last word",
+                "wraps",
+                "",
+                ""
+            };
+
+            _ts.Text = "This is a long string where the last word wraps\n\n";
+            _ts.LineLength = 200;
+
+            var result = _ts.SplitIntoLines();
+
+            Assert.That(result, Has.Count.EqualTo(4));
+            CollectionAssert.AreEqual(expectedLines, result);
+        }
+
+        [Test]
+        [Timeout(2000)]
+        public void GivenMessageWhereLastWordHasLeadingAndTrailingNewLines_WhenSplitting_HasExpectedNumberOfNewlines()
+        {
+            var expectedLines = new[]
+            {
+                "This is a long string where the last word",
+                "wraps",
+                ""
+            };
+
+            _ts.Text = "This is a long string where the last word \nwraps\n";
+            _ts.LineLength = 200;
+
+            var result = _ts.SplitIntoLines();
+
+            Assert.That(result, Has.Count.EqualTo(3));
             CollectionAssert.AreEqual(expectedLines, result);
         }
 

--- a/XNAControls/XNAButton.cs
+++ b/XNAControls/XNAButton.cs
@@ -69,10 +69,6 @@ namespace XNAControls
         /// <param name="overSource">Source within the sprite sheet that contains the texture to draw on MouseOver</param>
         public XNAButton(Texture2D sheet, Vector2 location, Rectangle outSource, Rectangle overSource)
         {
-            if (outSource == null)
-                throw new ArgumentNullException(nameof(outSource));
-            if (overSource == null)
-                throw new ArgumentNullException(nameof(outSource));
             _sheet = sheet ?? throw new ArgumentNullException(nameof(sheet));
             _outSource = outSource;
             _overSource = overSource;

--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -13,9 +13,9 @@
     <PackageTags>utility library UI cross-platform controls XNA MonoGame</PackageTags>
     <Copyright>Copyright © 2016-2023 Ethan Moffat</Copyright>
     <Description>Cross-platform UI control library for MonoGame/XNA.</Description>
-    <Version>1.7.0</Version>
-    <AssemblyVersion>1.7.0</AssemblyVersion>
-    <PackageVersion>1.7.0</PackageVersion>
+    <Version>1.7.1</Version>
+    <AssemblyVersion>1.7.1</AssemblyVersion>
+    <PackageVersion>1.7.1</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303">

--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -18,6 +18,19 @@
     <PackageVersion>1.7.1</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\CppNet.dll" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\libmojoshader_64.dll" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.deps.json" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.dll" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.exe" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.pdb" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.runtimeconfig.dev.json" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.runtimeconfig.json" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.D3DCompiler.dll" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.D3DCompiler.xml" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.dll" />
+    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.xml" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Extended" Version="3.8.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303">

--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -18,6 +18,8 @@
     <PackageVersion>1.7.1</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Extended" Version="3.8.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 1.7.0.$(rev:rrr)
+name: 1.7.1.$(rev:rrr)
 
 trigger:
 - master


### PR DESCRIPTION
Bitmap fonts are support in controls now. Interface is unchanged - the control will attempt to load a spritefont, if it fails, it will attempt to load a bitmap font.

TextSplitter updated to add support for hard line breaks with a hyphen and regular line breaks (old behavior). Hyphen character is settable.