### PR TITLE
Rewrite TextSplitter to use character-by-character splitting

### DIFF
--- a/XNAControls.Test/TextSplitterEOTest.cs
+++ b/XNAControls.Test/TextSplitterEOTest.cs
@@ -1,0 +1,125 @@
+﻿using Microsoft.Xna.Framework.Content;
+using MonoGame.Extended.BitmapFonts;
+using NUnit.Framework;
+using XNAControls.Test.Helpers;
+
+namespace XNAControls.Test
+{
+    [TestFixture]
+    public class TextSplitterEOTest
+    {
+        private TextSplitter _ts;
+        private static TestGameManager _gameManager;
+        private static BitmapFont _font;
+
+        [OneTimeSetUp]
+        public static void ClassInitialize()
+        {
+            _gameManager = new TestGameManager();
+            _font = LoadBitmapFontFromWorkingDirectory();
+        }
+
+        [OneTimeTearDown]
+        public static void ClassCleanup()
+        {
+            _gameManager?.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _ts = new TextSplitter("", _font)
+            {
+                LineLength = 102,
+                HardBreak = 150,
+                Hyphen = "-"
+            };
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void SordieMacroDisplaysCorrectly()
+        {
+            _ts.Text = @"  ___                  _ _    /  __|  __ _ _ __|  (_)__  \__ \/ _ \ '_/  _`  | / -_)  |___/\__/_| \__,_|,\__|";
+
+            var expected = new[]
+            {
+                @"  ___                  _ _   ",
+                @" /  __|  __ _ _ __|  (_)__ ",
+                @" \__ \/ _ \ '_/  _`  | / -_) ",
+                @" |___/\__/_| \__,_|,\__|"
+            };
+
+            var actual = _ts.SplitIntoLines();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void ByeMacroDisplaysCorrectly()
+        {
+            _ts.Text = @" ___               Byes     |  _  )_   _ ___  Byes   |  _  \ |_| /  - _)   Byes  |___/\_, \___|     Byes         |__/";
+
+            var expected = new[]
+            {
+                @" ___               Byes     ",
+                @"|  _  )_   _ ___  Byes   ",
+                @"|  _  \ |_| /  - _)   Byes ",
+                @" |___/\_, \___|     Byes ",
+                @"        |__/"
+            };
+
+            var actual = _ts.SplitIntoLines();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void STFUMacroDisplaysCorrectly()
+        {
+            _ts.Text = @"    __  ___  ___             /__`    |    |__    |      |    .__/   |    |        \__/    .";
+
+            var expected = new[]
+            {
+                @"    __  ___  ___          ",
+                @"   /__`    |    |__    |      | ",
+                @"   .__/   |    |        \__/ ",
+                @"   .",
+            };
+
+            var actual = _ts.SplitIntoLines();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        [Timeout(1000)]
+        public void LoveMacroDisplaysCorrectly()
+        {
+            _ts.Text = @" ,d88b.d88b,               8888888888    Sordie  Y8888888Y    Loves     Y8888Y        You            ''Y''\";
+
+            var expected = new[]
+            {
+                @" ,d88b.d88b,              ",
+                @" 8888888888    Sordie ",
+                @" Y8888888Y    Loves ",
+                @"    Y8888Y        You   ",
+                @"         ''Y''\"
+            };
+
+            var actual = _ts.SplitIntoLines();
+
+            CollectionAssert.AreEqual(expected, actual);
+        }
+
+        private static BitmapFont LoadBitmapFontFromWorkingDirectory()
+        {
+            using (var content = new ContentManager(_gameManager.Game.Services, TestContext.CurrentContext.TestDirectory))
+            {
+                return content.Load<BitmapFont>("bmp_font_for_testing");
+            }
+        }
+    }
+}

--- a/XNAControls.Test/TextSplitterTest.cs
+++ b/XNAControls.Test/TextSplitterTest.cs
@@ -51,24 +51,33 @@ namespace XNAControls.Test
 
             var result = _ts.SplitIntoLines();
 
-            Assert.AreEqual(1, result.Count);
+            Assert.That(result, Has.Exactly(1).Items);
+            Assert.That(result[0], Is.EqualTo(_ts.Text));
         }
 
         [Test]
         [Timeout(2000)]
-        public void GivenLongMessageWithLongWordsAndLineBreaks_WhenSplittingAt100px_HasExpectedLineBreaksAndHyphens()
+        public void GivenLongMessageWithLongWordsAndLineBreaks_WhenSplitting_HasExpectedLineBreaksAndHyphens()
         {
-            _ts.Text = "Testtwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n\nmessagewwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww oneee";
+            _ts.Text = "Testtreallylongmessagewithnospacestobreakthemessageintosmallerwords\n\nmessagewwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww oneee";
             _ts.LineLength = 150;
             _ts.HardBreak = 150;
             _ts.Hyphen = "-";
 
             var result = _ts.SplitIntoLines();
 
-            Assert.That(result, Has.Count.EqualTo(6));
-            Assert.That(result, Has.None.StartsWith(" "));
-            Assert.That(result[0], Does.EndWith(_ts.Hyphen));
-            Assert.That(result[3], Does.EndWith(_ts.Hyphen));
+            var expectedLines = new[]
+            {
+                "Testtreallylongmessagewithnosp-",
+                "acestobreakthemessageintosma-",
+                "llerwords",
+                "",
+                "messagewwwwwwwwwwwwww-",
+                "wwwwwwwwwwwwwwwwwww-",
+                "ww oneee"
+            };
+
+            CollectionAssert.AreEqual(expectedLines, result);
         }
 
         [Test]
@@ -181,7 +190,6 @@ namespace XNAControls.Test
 
             var result = _ts.SplitIntoLines();
 
-            Assert.That(result, Has.Count.EqualTo(3));
             CollectionAssert.AreEqual(new[] { ExpectedString, string.Empty, string.Empty }, result);
         }
 
@@ -212,18 +220,17 @@ namespace XNAControls.Test
         {
             var expectedLines = new[]
             {
-                "This is a long string where the last word",
+                "This is a long string where the very last word ",
                 "wraps",
                 "",
                 ""
             };
 
-            _ts.Text = "This is a long string where the last word wraps\n\n";
+            _ts.Text = "This is a long string where the very last word wraps\n\n";
             _ts.LineLength = 200;
 
             var result = _ts.SplitIntoLines();
 
-            Assert.That(result, Has.Count.EqualTo(4));
             CollectionAssert.AreEqual(expectedLines, result);
         }
 
@@ -233,7 +240,7 @@ namespace XNAControls.Test
         {
             var expectedLines = new[]
             {
-                "This is a long string where the last word",
+                "This is a long string where the last word ",
                 "wraps",
                 ""
             };
@@ -243,7 +250,6 @@ namespace XNAControls.Test
 
             var result = _ts.SplitIntoLines();
 
-            Assert.That(result, Has.Count.EqualTo(3));
             CollectionAssert.AreEqual(expectedLines, result);
         }
 

--- a/XNAControls.Test/XNAControls.Test.csproj
+++ b/XNAControls.Test/XNAControls.Test.csproj
@@ -18,5 +18,11 @@
     <None Include="font_for_testing.xnb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="bmp_font_for_testing.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="bmp_font_for_testing_0.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/XNAControls.Test/bmp_font_for_testing.xnb
+++ b/XNAControls.Test/bmp_font_for_testing.xnb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9910e1d565b4869d01ccfe74804f3c13535c7b6a561e95e0d313483a9195ca9c
+size 28310

--- a/XNAControls.Test/bmp_font_for_testing_0.xnb
+++ b/XNAControls.Test/bmp_font_for_testing_0.xnb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a32276d97ba4afdd2f656439d1c10b57f40325c91139014189651e1e2c633d5
+size 589909

--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -13,9 +13,9 @@
     <PackageTags>utility library UI cross-platform controls XNA MonoGame</PackageTags>
     <Copyright>Copyright © 2016-2023 Ethan Moffat</Copyright>
     <Description>Cross-platform UI control library for MonoGame/XNA.</Description>
-    <Version>1.7.2</Version>
-    <AssemblyVersion>1.7.2</AssemblyVersion>
-    <PackageVersion>1.7.2</PackageVersion>
+    <Version>1.7.3</Version>
+    <AssemblyVersion>1.7.3</AssemblyVersion>
+    <PackageVersion>1.7.3</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\CppNet.dll" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 1.7.2.$(rev:rrr)
+name: 1.7.3.$(rev:rrr)
 
 trigger:
 - master


### PR DESCRIPTION
Also preserves spaces and newlines better.

Also added test coverage, and test cases from EO.