### PR TITLE
Implement more events

### DIFF
--- a/XNAControls/Input/EventType.cs
+++ b/XNAControls/Input/EventType.cs
@@ -69,6 +69,14 @@ namespace XNAControls.Input
         /// </summary>
         KeyReleased = 0x2000,
         /// <summary>
+        /// MouseDown event
+        /// </summary>
+        MouseDown = 0x4000,
+        /// <summary>
+        /// MouseUp event
+        /// </summary>
+        MouseUp = 0x8000,
+        /// <summary>
         /// All events
         /// </summary>
         All = 0xFFFF

--- a/XNAControls/Input/EventType.cs
+++ b/XNAControls/Input/EventType.cs
@@ -11,58 +11,66 @@ namespace XNAControls.Input
         /// <summary>
         /// No event
         /// </summary>
-        None = 0,
+        None = 0x0000,
         /// <summary>
         /// MouseOver event
         /// </summary>
-        MouseOver = 1,
+        MouseOver = 0x0001,
         /// <summary>
         /// MouseEnter event
         /// </summary>
-        MouseEnter = 2,
+        MouseEnter = 0x0002,
         /// <summary>
         /// MouseLeave event
         /// </summary>
-        MouseLeave = 4,
+        MouseLeave = 0x0004,
         /// <summary>
         /// DragStart event
         /// </summary>
-        DragStart = 8,
+        DragStart = 0x0008,
         /// <summary>
         /// DragEnd event
         /// </summary>
-        DragEnd = 16,
+        DragEnd = 0x0010,
         /// <summary>
         /// Drag event
         /// </summary>
-        Drag = 32,
+        Drag = 0x0020,
         /// <summary>
         /// Click event
         /// </summary>
-        Click = 64,
+        Click = 0x0040,
         /// <summary>
         /// Double click event
         /// </summary>
-        DoubleClick = 128,
+        DoubleClick = 0x0080,
         /// <summary>
         /// Key typed event
         /// </summary>
-        KeyTyped = 256,
+        KeyTyped = 0x0100,
         /// <summary>
         /// Got focus event
         /// </summary>
-        GotFocus = 512,
+        GotFocus = 0x0200,
         /// <summary>
         /// Lost focus event
         /// </summary>
-        LostFocus = 1024,
+        LostFocus = 0x0400,
         /// <summary>
         /// MouseWheelMoved event
         /// </summary>
-        MouseWheelMoved = 2048,
+        MouseWheelMoved = 0x0800,
+        /// <summary>
+        /// KeyPressed event
+        /// </summary>
+        KeyPressed = 0x1000,
+        /// <summary>
+        /// KeyReleased event
+        /// </summary>
+        KeyReleased = 0x2000,
         /// <summary>
         /// All events
         /// </summary>
-        All = 0xfff
+        All = 0xFFFF
     }
 }

--- a/XNAControls/Input/InputManager.cs
+++ b/XNAControls/Input/InputManager.cs
@@ -50,6 +50,8 @@ namespace XNAControls.Input
         public override void Initialize()
         {
             _keyboardListener.KeyTyped += Keyboard_KeyTyped;
+            _keyboardListener.KeyPressed += Keyboard_KeyPressed;
+            _keyboardListener.KeyReleased += Keyboard_KeyReleased;
             _mouseListener.MouseClicked += Mouse_Click;
             _mouseListener.MouseDoubleClicked += Mouse_DoubleClick;
             _mouseListener.MouseDragStart += Mouse_DragStart;
@@ -100,6 +102,16 @@ namespace XNAControls.Input
         {
             // todo: is there a better place to store which textbox is focused?
             XNATextBox.FocusedTextbox?.PostMessage(EventType.KeyTyped, e);
+        }
+
+        private void Keyboard_KeyPressed(object sender, KeyboardEventArgs e)
+        {
+            XNATextBox.FocusedTextbox?.PostMessage(EventType.KeyPressed, e);
+        }
+
+        private void Keyboard_KeyReleased(object sender, KeyboardEventArgs e)
+        {
+            XNATextBox.FocusedTextbox?.PostMessage(EventType.KeyReleased, e);
         }
 
         private void Mouse_Click(object sender, MouseEventArgs e)

--- a/XNAControls/Input/InputManager.cs
+++ b/XNAControls/Input/InputManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 using Microsoft.Xna.Framework;
 
@@ -16,6 +17,7 @@ namespace XNAControls.Input
         private readonly MouseListener _mouseListener;
 
         private IEventReceiver _dragTarget;
+        private bool _componentsChanged;
 
         /// <summary>
         /// Create a new InputManager using the default game previously set in the GameRepository
@@ -41,6 +43,19 @@ namespace XNAControls.Input
             _mouseListener = new MouseListener(mouseListenerSettings);
 
             UpdateOrder = int.MinValue;
+
+            Game.Components.ComponentAdded += Components_ComponentAdded;
+            Game.Components.ComponentRemoved += Components_ComponentRemoved;
+
+            void Components_ComponentRemoved(object sender, GameComponentCollectionEventArgs e)
+            {
+                _componentsChanged = true;
+            }
+
+            void Components_ComponentAdded(object sender, GameComponentCollectionEventArgs e)
+            {
+                _componentsChanged = true;
+            }
         }
 
         /// <inheritdoc />
@@ -65,7 +80,7 @@ namespace XNAControls.Input
         public override void Update(GameTime gameTime)
         {
             var mouseState = MouseExtended.GetState();
-            if (mouseState.PositionChanged)
+            if (mouseState.PositionChanged || _componentsChanged)
             {
                 var comps = InputTargetFinder.GetMouseOverEventTargetControl(Game.Components);
                 foreach (var component in comps)
@@ -89,6 +104,8 @@ namespace XNAControls.Input
                         Mouse_Leave(component, mouseState);
                     }
                 }
+
+                _componentsChanged = false;
             }
 
             _keyboardListener.Update(gameTime);

--- a/XNAControls/Input/InputManager.cs
+++ b/XNAControls/Input/InputManager.cs
@@ -4,8 +4,6 @@ using Microsoft.Xna.Framework;
 
 using MonoGame.Extended.Input;
 using MonoGame.Extended.Input.InputListeners;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace XNAControls.Input
 {
@@ -51,6 +49,8 @@ namespace XNAControls.Input
             _keyboardListener.KeyTyped += Keyboard_KeyTyped;
             _keyboardListener.KeyPressed += Keyboard_KeyPressed;
             _keyboardListener.KeyReleased += Keyboard_KeyReleased;
+            _mouseListener.MouseDown += Mouse_Down;
+            _mouseListener.MouseUp += Mouse_Up;
             _mouseListener.MouseClicked += Mouse_Click;
             _mouseListener.MouseDoubleClicked += Mouse_DoubleClick;
             _mouseListener.MouseDragStart += Mouse_DragStart;
@@ -113,15 +113,27 @@ namespace XNAControls.Input
             XNATextBox.FocusedTextbox?.PostMessage(EventType.KeyReleased, e);
         }
 
+        private void Mouse_Down(object sender, MouseEventArgs e)
+        {
+            var clickTarget = InputTargetFinder.GetMouseButtonEventTargetControl(Game.Components);
+            clickTarget?.PostMessage(EventType.MouseDown, e);
+        }
+
+        private void Mouse_Up(object sender, MouseEventArgs e)
+        {
+            var clickTarget = InputTargetFinder.GetMouseButtonEventTargetControl(Game.Components);
+            clickTarget?.PostMessage(EventType.MouseUp, e);
+        }
+
         private void Mouse_Click(object sender, MouseEventArgs e)
         {
-            var clickTarget = InputTargetFinder.GetMouseDownEventTargetControl(Game.Components);
+            var clickTarget = InputTargetFinder.GetMouseButtonEventTargetControl(Game.Components);
             clickTarget?.PostMessage(EventType.Click, e);
         }
 
         private void Mouse_DoubleClick(object sender, MouseEventArgs e)
         {
-            var clickTarget = InputTargetFinder.GetMouseDownEventTargetControl(Game.Components);
+            var clickTarget = InputTargetFinder.GetMouseButtonEventTargetControl(Game.Components);
             clickTarget?.PostMessage(EventType.DoubleClick, e);
         }
 
@@ -130,7 +142,7 @@ namespace XNAControls.Input
             if (_dragTarget != null)
                 return;
 
-            _dragTarget = InputTargetFinder.GetMouseDownEventTargetControl(Game.Components);
+            _dragTarget = InputTargetFinder.GetMouseButtonEventTargetControl(Game.Components);
             _dragTarget?.PostMessage(EventType.DragStart, e);
         }
 
@@ -153,7 +165,7 @@ namespace XNAControls.Input
 
         private void Mouse_WheelMoved(object sender, MouseEventArgs e)
         {
-            var clickTarget = InputTargetFinder.GetMouseDownEventTargetControl(Game.Components);
+            var clickTarget = InputTargetFinder.GetMouseButtonEventTargetControl(Game.Components);
             clickTarget?.PostMessage(EventType.MouseWheelMoved, e);
         }
 

--- a/XNAControls/Input/InputTargetFinder.cs
+++ b/XNAControls/Input/InputTargetFinder.cs
@@ -31,7 +31,7 @@ namespace XNAControls.Input
             return targets;
         }
 
-        internal static IEventReceiver GetMouseDownEventTargetControl(IEnumerable<IGameComponent> collection, bool includeChildren = true)
+        internal static IEventReceiver GetMouseButtonEventTargetControl(IEnumerable<IGameComponent> collection, bool includeChildren = true)
         {
             var targets = collection
                 .OfType<IEventReceiver>()

--- a/XNAControls/Input/InputTargetFinder.cs
+++ b/XNAControls/Input/InputTargetFinder.cs
@@ -6,7 +6,9 @@ namespace XNAControls.Input
 {
     internal static class InputTargetFinder
     {
-        public static IEnumerable<IEventReceiver> GetMouseOverEventTargetControl(IEnumerable<IGameComponent> collection, Point position)
+        internal static Dictionary<object, bool> MouseOverState { get; } = [];
+
+        internal static IEnumerable<IEventReceiver> GetMouseOverEventTargetControl(IEnumerable<IGameComponent> collection)
         {
             var targets = collection
                 .OfType<IEventReceiver>()
@@ -29,21 +31,21 @@ namespace XNAControls.Input
             return targets;
         }
 
-        public static IEventReceiver GetMouseDownEventTargetControl(IEnumerable<IGameComponent> collection, Point position, bool includeChildren = true)
+        internal static IEventReceiver GetMouseDownEventTargetControl(IEnumerable<IGameComponent> collection, bool includeChildren = true)
         {
             var targets = collection
                 .OfType<IEventReceiver>()
-                .Where(x => IsValidMouseDownTarget(x, position))
+                .Where(IsValidMouseDownTarget)
                 .ToList();
 
             if (includeChildren)
             {
                 var toProcess = new Queue<IXNAControl>(targets.OfType<IXNAControl>());
-                while (toProcess.Any())
+                while (toProcess.Count != 0)
                 {
                     var parent = toProcess.Dequeue();
 
-                    var childtargets = parent.ChildControls.Where(x => IsValidMouseDownTarget(x, position));
+                    var childtargets = parent.ChildControls.Where(IsValidMouseDownTarget);
                     foreach (var child in childtargets)
                         toProcess.Enqueue(child);
 
@@ -52,7 +54,7 @@ namespace XNAControls.Input
                 }
             }
 
-            if (!targets.Any()) return null;
+            if (targets.Count == 0) return null;
             if (targets.Count == 1) return targets.Single();
 
             var max = targets.Max(x => x.ZOrder);
@@ -80,15 +82,15 @@ namespace XNAControls.Input
             return component as IDrawable == null || ((IDrawable)component).Visible;
         }
 
-        private static bool IsValidMouseDownTarget(IEventReceiver eventReceiver, Point position)
+        private static bool IsValidMouseDownTarget(IEventReceiver eventReceiver)
         {
-            return eventReceiver.EventArea.Contains(position) && AllParentsVisible(eventReceiver);
+            return MouseOverState.TryGetValue(eventReceiver, out var mouseOver)
+                && mouseOver && AllParentsVisible(eventReceiver);
         }
 
         private static bool AllParentsVisible(IEventReceiver eventReceiver)
         {
-            var control = eventReceiver as IXNAControl;
-            if (control == null)
+            if (eventReceiver is not IXNAControl control)
             {
                 var drawable = eventReceiver as IDrawable;
                 return drawable?.Visible ?? true;

--- a/XNAControls/XNAButton.cs
+++ b/XNAControls/XNAButton.cs
@@ -33,15 +33,17 @@ namespace XNAControls
 
         private long _lastFlashTick;
 
-        /// <summary>
-        /// Invoked when the button control is clicked once
-        /// </summary>
-        public event EventHandler<MouseEventArgs> OnClick;
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnMouseDown = delegate { };
 
-        /// <summary>
-        /// Invoked when the button control is being dragged
-        /// </summary>
-        public event EventHandler<MouseEventArgs> OnClickDrag;
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnMouseUp = delegate { };
+
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnClick = delegate { };
+
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnClickDrag = delegate { };
 
         /// <summary>
         /// Set the FlashSpeed which causes the over/out textures to cycle once every 'FlashSpeed' milliseconds
@@ -132,6 +134,28 @@ namespace XNAControls
         }
 
         /// <inheritdoc />
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (OnMouseDown == null)
+                return false;
+
+            OnMouseDown(control, eventArgs);
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleMouseUp(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (OnMouseUp == null)
+                return false;
+
+            OnMouseUp(control, eventArgs);
+
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (OnClick == null)
@@ -148,6 +172,16 @@ namespace XNAControls
     /// </summary>
     public interface IXNAButton : IXNAControl
     {
+        /// <summary>
+        /// Invoked when a mouse button is pressed on a button control
+        /// </summary>
+        event EventHandler<MouseEventArgs> OnMouseDown;
+
+        /// <summary>
+        /// Invoked when a mouse button is released on a button control
+        /// </summary>
+        event EventHandler<MouseEventArgs> OnMouseUp;
+
         /// <summary>
         /// Invoked when the button control is clicked once
         /// </summary>

--- a/XNAControls/XNAControl.cs
+++ b/XNAControls/XNAControl.cs
@@ -406,6 +406,8 @@ namespace XNAControls
                 case EventType.DragStart: handled = HandleDragStart(this, (MouseEventArgs)eventArgs); break;
                 case EventType.DragEnd: handled = HandleDragEnd(this, (MouseEventArgs)eventArgs); break;
                 case EventType.Drag: handled = HandleDrag(this, (MouseEventArgs)eventArgs); break;
+                case EventType.MouseDown: handled = HandleMouseDown(this, (MouseEventArgs)eventArgs); break;
+                case EventType.MouseUp: handled = HandleMouseUp(this, (MouseEventArgs)eventArgs); break;
                 case EventType.Click: handled = HandleClick(this, (MouseEventArgs)eventArgs); break;
                 case EventType.DoubleClick: handled = HandleDoubleClick(this, (MouseEventArgs)eventArgs);  break;
                 case EventType.KeyTyped: handled = HandleKeyTyped(this, (KeyboardEventArgs)eventArgs); break;
@@ -433,6 +435,16 @@ namespace XNAControls
         /// Default handler for Drag event
         /// </summary>
         protected virtual bool HandleDrag(IXNAControl control, MouseEventArgs eventArgs) => false;
+
+        /// <summary>
+        /// Default handler for MouseDown event
+        /// </summary>
+        protected virtual bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs) => false;
+
+        /// <summary>
+        /// Default handler for MouseUp event
+        /// </summary>
+        protected virtual bool HandleMouseUp(IXNAControl control, MouseEventArgs eventArgs) => false;
 
         /// <summary>
         /// Default handler for Click event

--- a/XNAControls/XNAControl.cs
+++ b/XNAControls/XNAControl.cs
@@ -409,6 +409,8 @@ namespace XNAControls
                 case EventType.Click: handled = HandleClick(this, (MouseEventArgs)eventArgs); break;
                 case EventType.DoubleClick: handled = HandleDoubleClick(this, (MouseEventArgs)eventArgs);  break;
                 case EventType.KeyTyped: handled = HandleKeyTyped(this, (KeyboardEventArgs)eventArgs); break;
+                case EventType.KeyPressed: handled = HandleKeyPressed(this, (KeyboardEventArgs)eventArgs); break;
+                case EventType.KeyReleased: handled = HandleKeyReleased(this, (KeyboardEventArgs)eventArgs); break;
                 case EventType.GotFocus: handled = HandleGotFocus(this, EventArgs.Empty); break;
                 case EventType.LostFocus: handled = HandleLostFocus(this, EventArgs.Empty); break;
                 case EventType.MouseWheelMoved: handled = HandleMouseWheelMoved(this, (MouseEventArgs)eventArgs); break;
@@ -446,6 +448,16 @@ namespace XNAControls
         /// Default handler for KeyTyped event
         /// </summary>
         protected virtual bool HandleKeyTyped(IXNAControl control, KeyboardEventArgs eventArgs) => false;
+
+        /// <summary>
+        /// Default handler for KeyPressed event
+        /// </summary>
+        protected virtual bool HandleKeyPressed(IXNAControl control, KeyboardEventArgs eventArgs) => false;
+
+        /// <summary>
+        /// Default handler for KeyReleased event
+        /// </summary>
+        protected virtual bool HandleKeyReleased(IXNAControl control, KeyboardEventArgs eventArgs) => false;
 
         /// <summary>
         /// Default handler for GotFocus event

--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -18,18 +18,7 @@
     <PackageVersion>2.3.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\CppNet.dll" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\libmojoshader_64.dll" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.deps.json" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.dll" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.exe" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.pdb" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.runtimeconfig.dev.json" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\mgfxc.runtimeconfig.json" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.D3DCompiler.dll" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.D3DCompiler.xml" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.dll" />
-    <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\SharpDX.xml" />
+    <Content Remove="..\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\*.*" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Extended" Version="3.8.0" />

--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -13,9 +13,9 @@
     <PackageTags>utility library UI cross-platform controls XNA MonoGame</PackageTags>
     <Copyright>Copyright © 2016-2024 Ethan Moffat</Copyright>
     <Description>Cross-platform UI control library for MonoGame</Description>
-    <Version>2.2.0</Version>
-    <AssemblyVersion>2.2.0</AssemblyVersion>
-    <PackageVersion>2.2.0</PackageVersion>
+    <Version>2.3.0</Version>
+    <AssemblyVersion>2.3.0</AssemblyVersion>
+    <PackageVersion>2.3.0</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Remove="C:\Users\ethan\.nuget\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\CppNet.dll" />

--- a/XNAControls/XNAHyperLink.cs
+++ b/XNAControls/XNAHyperLink.cs
@@ -12,14 +12,16 @@ namespace XNAControls
     {
         private Color _temporaryForeColor;
 
-        /// <summary>
-        /// Color for the link when the mouse is over the link
-        /// </summary>
+        /// <inheritdoc />
         public Color MouseOverColor { get; set; }
 
-        /// <summary>
-        /// Event that is invoked when the link is clicked
-        /// </summary>
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnMouseDown = delegate { };
+
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnMouseUp = delegate { };
+
+        /// <inheritdoc />
         public event EventHandler<MouseEventArgs> OnClick = delegate { };
 
         /// <summary>
@@ -38,12 +40,35 @@ namespace XNAControls
         }
 
         /// <inheritdoc />
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (OnMouseDown == null)
+                return false;
+
+            OnMouseDown(control, eventArgs);
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleMouseUp(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (OnMouseUp == null)
+                return false;
+
+            OnMouseUp(control, eventArgs);
+
+            return true;
+        }
+
+        /// <inheritdoc />
         protected override bool HandleClick(IXNAControl control, MouseEventArgs eventArgs)
         {
             if (OnClick == null)
                 return false;
 
             OnClick?.Invoke(control, eventArgs);
+
             return true;
         }
 
@@ -71,7 +96,17 @@ namespace XNAControls
         Color MouseOverColor { get; set; }
 
         /// <summary>
-        /// Event that is invoked when the link is clicked
+        /// Invoked when a mouse button is pressed on a button control
+        /// </summary>
+        event EventHandler<MouseEventArgs> OnMouseDown;
+
+        /// <summary>
+        /// Invoked when a mouse button is released on a button control
+        /// </summary>
+        event EventHandler<MouseEventArgs> OnMouseUp;
+
+        /// <summary>
+        /// Invoked when the link is clicked
         /// </summary>
         event EventHandler<MouseEventArgs> OnClick;
     }

--- a/XNAControls/XNALabel.cs
+++ b/XNAControls/XNALabel.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using MonoGame.Extended.BitmapFonts;
@@ -205,14 +208,23 @@ namespace XNAControls
         /// <inheritdoc />
         protected override void LoadContent()
         {
-            try
-            {
-                _sFont = Game.Content.Load<SpriteFont>(_spriteFontName);
-            }
-            catch
+            var contentFile = Path.Combine(Game.Content.RootDirectory, $"{_spriteFontName}.xnb");
+
+            using var st = File.OpenRead(contentFile);
+            using var br = new BinaryReader(st, Encoding.UTF8);
+
+            var importerLen = br.Read7BitEncodedInt();
+            var importer = Encoding.UTF8.GetString(br.ReadBytes(importerLen));
+
+            _isBitmapFont = importer.Contains("MonoGame.Extended.BitmapFonts.BitmapFontReader");
+
+            if (_isBitmapFont)
             {
                 _bFont = Game.Content.Load<BitmapFont>(_spriteFontName);
-                _isBitmapFont = true;
+            }
+            else
+            {
+                _sFont = Game.Content.Load<SpriteFont>(_spriteFontName);
             }
 
             _rowHeight ??= LineHeight;

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -170,6 +170,12 @@ namespace XNAControls
         public event EventHandler OnEnterPressed = delegate { };
 
         /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnMouseDown = delegate { };
+
+        /// <inheritdoc />
+        public event EventHandler<MouseEventArgs> OnMouseUp = delegate { };
+
+        /// <inheritdoc />
         public event EventHandler<MouseEventArgs> OnClicked = delegate { };
 
         /// <summary>
@@ -288,6 +294,28 @@ namespace XNAControls
             _spriteBatch.End();
 
             base.OnDrawControl(gameTime);
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleMouseDown(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (OnMouseDown == null)
+                return false;
+
+            OnMouseDown(control, eventArgs);
+
+            return true;
+        }
+
+        /// <inheritdoc />
+        protected override bool HandleMouseUp(IXNAControl control, MouseEventArgs eventArgs)
+        {
+            if (OnMouseUp == null)
+                return false;
+
+            OnMouseUp(control, eventArgs);
+
+            return true;
         }
 
         /// <inheritdoc />
@@ -559,6 +587,16 @@ namespace XNAControls
         /// Event fired when the enter key is pressed
         /// </summary>
         event EventHandler OnEnterPressed;
+
+        /// <summary>
+        /// Event fired when a mouse button is pressed on a button control
+        /// </summary>
+        event EventHandler<MouseEventArgs> OnMouseDown;
+
+        /// <summary>
+        /// Event fired when a mouse button is released on a button control
+        /// </summary>
+        event EventHandler<MouseEventArgs> OnMouseUp;
 
         /// <summary>
         /// Event fired when this text box is clicked

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 2.2.0.$(rev:rrr)
+name: 2.3.0.$(rev:rrr)
 
 pr:
 - master

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="repositoryPath" value="packages" />
+    <add key="globalPackagesFolder" value="packages" />
+  </config>
+</configuration>


### PR DESCRIPTION
Add handling for additional events:
- `KeyPressed`/`KeyReleased`: these are necessary to detect keys without an associated `char` character value (MonoGame.Extended implementation detail).
- `MouseDown`/`MouseUp`: these provide more flexibility beyond just detecting "click" events. "Click" events are also often in conflict with double-click detection.

Minor optimizations:
- Don't rely on thrown exception to determine if a font is a BitmapFont or SpriteFont; instead, parse the XNB file header to determine file type.
- Re-use MouseOver state so that it doesn't need to be re-calculated when selecting a control for click events.