### PR TITLE
Fix path for font content on macOS

### DIFF
--- a/XNAControls/XNAControls.csproj
+++ b/XNAControls/XNAControls.csproj
@@ -13,9 +13,9 @@
     <PackageTags>utility library UI cross-platform controls XNA MonoGame</PackageTags>
     <Copyright>Copyright © 2016-2024 Ethan Moffat</Copyright>
     <Description>Cross-platform UI control library for MonoGame</Description>
-    <Version>2.3.0</Version>
-    <AssemblyVersion>2.3.0</AssemblyVersion>
-    <PackageVersion>2.3.0</PackageVersion>
+    <Version>2.3.1</Version>
+    <AssemblyVersion>2.3.1</AssemblyVersion>
+    <PackageVersion>2.3.1</PackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <Content Remove="..\packages\monogame.extended\3.8.0\contentFiles\any\netstandard2.0\*.*" />

--- a/XNAControls/XNALabel.cs
+++ b/XNAControls/XNALabel.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 
 using Microsoft.Xna.Framework;
@@ -208,7 +209,9 @@ namespace XNAControls
         /// <inheritdoc />
         protected override void LoadContent()
         {
-            var contentFile = Path.Combine(Game.Content.RootDirectory, $"{_spriteFontName}.xnb");
+            var contentFile = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? Path.Combine("Contents", "Resources", Game.Content.RootDirectory, $"{_spriteFontName}.xnb")
+                : Path.Combine(Game.Content.RootDirectory, $"{_spriteFontName}.xnb");
 
             using var st = File.OpenRead(contentFile);
             using var br = new BinaryReader(st, Encoding.UTF8);

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,4 @@
-name: 2.3.0.$(rev:rrr)
+name: 2.3.1.$(rev:rrr)
 
 pr:
 - master


### PR DESCRIPTION
Loading a content file on macOS assumes a base path of "Contents/Resources" for anything in an app bundle. This prefix path is prepended to Game.Content.RootDirectory when loading content, but not when accessing Game.Content.RootDirectory (annoying).